### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,7 @@ Effortlessly integrate [Neo4j](https://github.com/neo4j/neo4j) powerful graph da
 1. Add `nuxt-neo4j` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-neo4j
-
-# Using yarn
-yarn add --dev nuxt-neo4j
-
-# Using npm
-npm install --save-dev nuxt-neo4j
+npx nuxi@latest module add neo4j
 ```
 
 2. Add `nuxt-neo4j` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
